### PR TITLE
Add public job scraper script with Python job filtering and JSON output (#1)

### DIFF
--- a/public-job-scraper/README.md
+++ b/public-job-scraper/README.md
@@ -1,0 +1,78 @@
+
+# 📄 Public Job Scraper
+
+A beginner-friendly Python script that scrapes Python-related job listings from a public job board (Real Python's demo site). It extracts job **titles**, **company names**, and **links**, then saves the results in a **timestamped JSON file**.
+
+---
+
+## 🧠 What It Does
+
+- 🔍 Scrapes job data from: [https://realpython.github.io/fake-jobs/](https://realpython.github.io/fake-jobs/)
+- ✅ Filters only **Python**-related jobs
+- 🏷 Extracts:
+  - Job title
+  - Company name
+  - Job application link
+- 💾 Saves the output as a JSON file in the `output/` directory (e.g., `jobs_2025-06-25_14-40-02.json`)
+
+---
+
+## 📂 Folder Structure
+
+```bash
+public-job-scraper/
+├── main.py               # Main scraping script
+├── requirements.txt      # Required Python packages
+├── output/               # Stores JSON job data files
+└── README.md             # You are here 📘
+```
+
+## 🚀 How to Run
+
+
+## 1. ✅ Clone the repository and navigate to the folder
+```bash
+git clone https://github.com/your-username/scraping-scripts-main.git
+cd scraping-scripts-main/public-job-scraper
+```
+
+## 2. 🧱 (Optional but Recommended) Create a virtual environment
+```
+python -m venv venv
+source venv/bin/activate      # On macOS/Linux
+venv\Scripts\activate         # On Windows
+```
+
+
+## 3. 📦 Install dependencies
+```
+pip install -r requirements.txt
+```
+## 4. ▶️ Run the script
+```
+python main.py
+```
+
+## Output:
+```
+# A timestamped .json file will be saved to the output/ folder
+```
+
+---
+
+## 📦 Example Output
+
+```json
+[
+    {
+        "title": "Senior Python Developer",
+        "company": "ExampleCorp",
+        "link": "https://realpython.github.io/fake-jobs/jobs/senior-python-developer-0.html"
+    },
+    {
+        "title": "Python QA Engineer",
+        "company": "CodeCheckers",
+        "link": "https://realpython.github.io/fake-jobs/jobs/python-qa-engineer-12.html"
+    }
+]
+```

--- a/public-job-scraper/main.py
+++ b/public-job-scraper/main.py
@@ -1,0 +1,71 @@
+"""
+Scrapes job titles, company names, and job links from a static job board
+(Real Python's demo site) and saves them to a timestamped JSON file.
+"""
+
+import requests
+from bs4 import BeautifulSoup
+import json
+import os
+from datetime import datetime
+
+def scrape_jobs(url: str, output_dir: str):
+    """
+    Fetches Python-related job listings from a static page and writes them to a timestamped JSON file.
+
+    Args:
+        url (str): The job board URL to scrape.
+        output_dir (str): Directory to save the output JSON.
+    """
+
+    try:
+        # Make the HTTP request
+        response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"❌ Error fetching the page: {e}")
+        return
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+    jobs = []
+
+    # Parse job listings
+    for job_card in soup.select('div.card-content'):
+        title_tag = job_card.find('h2', class_='title')
+        company_tag = job_card.find('h3', class_='company')
+        link_tag = job_card.find('a', text='Apply')
+
+        if title_tag and company_tag and link_tag:
+            title = title_tag.text.strip()
+            company = company_tag.text.strip()
+            link = link_tag['href']
+
+            if 'python' in title.lower():
+                jobs.append({
+                    "title": title,
+                    "company": company,
+                    "link": link
+                })
+
+    if not jobs:
+        print("⚠️ No Python-related jobs found.")
+        return
+
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Timestamped filename
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    output_path = os.path.join(output_dir, f"jobs_{timestamp}.json")
+
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(jobs, f, ensure_ascii=False, indent=4)
+        print(f"✅ Saved {len(jobs)} Python jobs to '{output_path}'")
+    except Exception as e:
+        print(f"❌ Failed to write JSON: {e}")
+
+if __name__ == "__main__":
+    target_url = "https://realpython.github.io/fake-jobs/"
+    output_folder = "output"
+    scrape_jobs(target_url, output_folder)

--- a/public-job-scraper/output/jobs_2025-06-27_23-23-30.json
+++ b/public-job-scraper/output/jobs_2025-06-27_23-23-30.json
@@ -1,0 +1,52 @@
+[
+    {
+        "title": "Senior Python Developer",
+        "company": "Payne, Roberts and Davis",
+        "link": "https://realpython.github.io/fake-jobs/jobs/senior-python-developer-0.html"
+    },
+    {
+        "title": "Software Engineer (Python)",
+        "company": "Garcia PLC",
+        "link": "https://realpython.github.io/fake-jobs/jobs/software-engineer-python-10.html"
+    },
+    {
+        "title": "Python Programmer (Entry-Level)",
+        "company": "Moss, Duncan and Allen",
+        "link": "https://realpython.github.io/fake-jobs/jobs/python-programmer-entry-level-20.html"
+    },
+    {
+        "title": "Python Programmer (Entry-Level)",
+        "company": "Cooper and Sons",
+        "link": "https://realpython.github.io/fake-jobs/jobs/python-programmer-entry-level-30.html"
+    },
+    {
+        "title": "Software Developer (Python)",
+        "company": "Adams-Brewer",
+        "link": "https://realpython.github.io/fake-jobs/jobs/software-developer-python-40.html"
+    },
+    {
+        "title": "Python Developer",
+        "company": "Rivera and Sons",
+        "link": "https://realpython.github.io/fake-jobs/jobs/python-developer-50.html"
+    },
+    {
+        "title": "Back-End Web Developer (Python, Django)",
+        "company": "Stewart-Alexander",
+        "link": "https://realpython.github.io/fake-jobs/jobs/back-end-web-developer-python-django-60.html"
+    },
+    {
+        "title": "Back-End Web Developer (Python, Django)",
+        "company": "Jackson, Ali and Mckee",
+        "link": "https://realpython.github.io/fake-jobs/jobs/back-end-web-developer-python-django-70.html"
+    },
+    {
+        "title": "Python Programmer (Entry-Level)",
+        "company": "Mathews Inc",
+        "link": "https://realpython.github.io/fake-jobs/jobs/python-programmer-entry-level-80.html"
+    },
+    {
+        "title": "Software Developer (Python)",
+        "company": "Moreno-Rodriguez",
+        "link": "https://realpython.github.io/fake-jobs/jobs/software-developer-python-90.html"
+    }
+]

--- a/public-job-scraper/requirements.txt
+++ b/public-job-scraper/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## 📌 Description

This PR adds a Python-based public job scraper under the `public-job-scraper/` folder.

The script scrapes Python-related jobs from Real Python's demo site and saves the output as a timestamped JSON file. A complete usage guide, dependency list, and folder breakdown are included in the script's README.

## 🚀 Highlights

- Filters jobs by "Python" in title
- Extracts title, company, and link
- Saves results to output/jobs_<timestamp>.json
- Uses `requests` + `beautifulsoup4`

> 📖 For setup instructions and detailed usage, see `public-job-scraper/README.md`.

## 🙌 Related Issue

Closes #1 
